### PR TITLE
Replaced todos with links to talk recordings and slides in PDF.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ Made with ❤ thanks to QWERTY keyboards and [asciidoctor-pdf.js](https://github
 
 ## (2022) Microdosing Rust: Why & How to Get Started with AVR?
 
-@todo link to PDF
+### [talk (Youtube)](https://youtu.be/3o_lzQMLU5Q)  |   [talk (Invidious)](https://yewtu.be/watch?v=3o_lzQMLU5Q)    |   [slides (PDF)](https://web.archive.org/web/20231004204001/https://pwy.io/talks/2022-microdosing-rust.pdf)
 
 ## (2020) Can't Hack This: A hard-headed introduction to Nix
 
-@todo link to PDF
+### [talk (Youtube)](https://youtu.be/LBrWwZOjsQ4)  |   [talk (Invidious)](https://yewtu.be/watch?v=LBrWwZOjsQ4)    |   [slides (PDF)](https://files.pwy.io/2020-cant-hack-this.pdf)
 
 ## (2020) Scary Acronyms (and Super Creeps): A take on OIBITs, HRTBs, and other charming abbreviations
 
-@todo link to PDF
+### [talk (Youtube)](https://youtu.be/6Qi5-VU-kS0)  |   [talk (Invidious)](https://yewtu.be/watch?v=6Qi5-VU-kS0)    |   [slides (PDF)](https://github.com/Rust-Wroclaw/rust-wroclaw/blob/master/talk-archive/2020-05-scary-acronyms-and-super-creeps.pdf?raw=true)
 
 ## (2020) Fantastic Actors and Where to Find Them: Building a simple async actor system from scratch
 
-@todo link to PDF
+### [slides (PDF)](https://files.pwy.io/2020-fantastic-actors.pdf)
 


### PR DESCRIPTION
Thank you for your talks, very informative.

Took me a bit longer than expected, but all 4 talks have sets of links to them with formatting.

"Microdosing Rust"'s PDF is 404 at pwy.io, hence link to Internet Archive.

Could not find any audio/video for "Fantastic Actors and Where to Find Them" talk.

Have a nice day and I wish I could attend one of your talks someday.